### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-echarts",
-  "version": "0.2.1",
+  "version": "0.3.4",
   "homepage": "https://github.com/wangshijun/angular-echarts",
   "authors": [
     "wangshijun2010 <wangshijun2010@gmail.com>"


### PR DESCRIPTION
error:
bower angular-echarts#*       mismatch Version declared in the json (0.2.1) is different than the resolved one (0.3.4)